### PR TITLE
Fix broken links in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@
 > This README is for the unreleased main branch, please reference the [official docs][docs]
 > for the latest stable release.
 
-[docs]: https://oban.pro/docs/py
-[uv]: https://docs.astral.sh/uv/
 
 ---
 
@@ -206,6 +204,8 @@ and start processing with the CLI (or embedded mode).
 
 For more details, see the [full documentation][docs].
 
+[docs]: https://oban.pro/docs/py
+[uv]: https://docs.astral.sh/uv/
 <!-- INDEX END -->
 
 ## Also Available


### PR DESCRIPTION
I saw some broken links in the [documentation](https://oban.pro/docs/py/0.5.0/index.html#installation) but not on GitHub. This is because when Sphinx imports the index block [here](https://github.com/oban-bg/oban-py/blob/main/docs/index.md?plain=1#L6), the cross references are not imported (because they are outside the block). So I move the references to the end of the block.