### PR TITLE
Call python http.server from uv in makefile docs-serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ docs:
 docs-serve:
 	DOCS_SWITCHER_URL="_static/switcher.json" uv run --group docs sphinx-build -b html docs docs/_build
 	@echo "Serving documentation at http://localhost:8000"
-	@cd docs/_build && python -m http.server 8000
+	@cd docs/_build && uv run python -m http.server 8000
 
 docs-clean:
 	rm -rf docs/_build


### PR DESCRIPTION
`make docs-serve` fails for me because i have only `python3` but no `python` on the path. It's easy to fix, but is even easier to (ab)use uv.