### PR TITLE
Correctly parse `@weekly` CRON alias

### DIFF
--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -19,6 +19,7 @@ class TestExpressionParse:
         assert {0} == Expression.parse("@hourly").minutes
         assert {0} == Expression.parse("@daily").hours
         assert {1} == Expression.parse("@monthly").days
+        assert {0} == Expression.parse("@weekly").weekdays
 
     def test_parsing_month_aliases(self):
         assert {1} == Expression.parse("* * * JAN *").months
@@ -26,7 +27,7 @@ class TestExpressionParse:
 
     def test_parsing_weekday_aliases(self):
         assert {1} == Expression.parse("* * * * MON").weekdays
-        assert {2, 7} == Expression.parse("* * * * SUN,TUE").weekdays
+        assert {0, 2} == Expression.parse("* * * * SUN,TUE").weekdays
 
     def test_parsing_upper_bounds(self):
         assert Expression.parse("59 23 31 12 7")
@@ -37,12 +38,18 @@ class TestExpressionParse:
             "* 24 * * *",
             "* * 32 * *",
             "* * * 13 *",
-            "* * * * 0",
+            "* * * * 8",
         ]
 
         for input in inputs:
             with pytest.raises(ValueError, match="out of range"):
                 Expression.parse(input)
+
+    def test_parsing_sunday_as_0_or_7(self):
+        assert {0} == Expression.parse("* * * * 0").weekdays
+        assert {0} == Expression.parse("* * * * 7").weekdays
+        assert {0, 1} == Expression.parse("* * * * 0,1").weekdays
+        assert {0, 1} == Expression.parse("* * * * 7,1").weekdays
 
     def test_parsing_unrecognized_expressions(self):
         inputs = [
@@ -190,7 +197,7 @@ class TestScheduledRegistration:
             async def process(self, job):
                 pass
 
-        @job(cron="@hourly")
+        @job(cron="@weekly")
         def business():
             pass
 


### PR DESCRIPTION
Parsing `@weekly` CRON `nickname` was raising an error, due to `0` being out of `1-7` range.

```python
oban/_scheduler.py:247: in parse
    weekdays=cls._parse_field(dow_part, DOW_SET),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

field = '0', allowed = frozenset({1, 2, 3, 4, 5, 6, ...})

    @staticmethod
    def _parse_field(field: str, allowed: set[int]) -> set[int]:
        parsed = set()
    
        for part in re.split(r"\s*,\s*", field):
            parsed.update(Expression._parse_part(part, allowed))
    
        if not parsed.issubset(allowed):
>           raise ValueError(f"field {field} is out of range: {allowed}")
E           ValueError: field 0 is out of range: frozenset({1, 2, 3, 4, 5, 6, 7})

oban/_scheduler.py:193: ValueError
```

[CRON Spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html) defines 0 as Sunday, and a range as 0-6.
Elixir Oban itself uses 0-6 ranges, so I assume it's either python adaptation OR a bug.

Nevertheless, modern CRON parsers treat 0 and 7 the same way, which is what I did in this PR.