### PR TITLE
Correctly handle async decorated jobs

### DIFF
--- a/oban/decorators.py
+++ b/oban/decorators.py
@@ -186,7 +186,10 @@ def job(*, oban: str = "oban", cron: str | dict | None = None, **overrides):
 
         class FunctionWorker:
             async def process(self, job: Job):
-                return func(**job.args)
+                result = func(**job.args)
+                if inspect.isawaitable(result):
+                    return await result
+                return result
 
         FunctionWorker.__name__ = func.__name__  # type: ignore[attr-defined]
         FunctionWorker.__module__ = func.__module__  # type: ignore[attr-defined]

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -1,6 +1,8 @@
+import asyncio
 import pytest
 
 from oban import job, worker
+from oban.testing import process_job
 
 
 class TestWorkerDecorator:
@@ -112,3 +114,18 @@ class TestJobDecorator:
             @job(cron="* * *")
             def bad_task():
                 pass
+
+    def test_async_job_functions_are_awaited(self):
+        executed = False
+
+        @job()
+        async def async_task():
+            nonlocal executed
+            executed = True
+            return "ok"
+
+        result = process_job(async_task.new())
+
+        assert not asyncio.iscoroutine(result)
+        assert executed
+        assert result == "ok"


### PR DESCRIPTION
From the docs:
```
### Testing Function Workers

Function-based workers created with `@job` can be tested the same way:

from oban import job
from oban.testing import process_job

@job(queue="default")
async def send_notification(user_id: int, message: str):
    await NotificationService.send(user_id, message)
    return {"sent": True}

async def test_send_notification():
    job = send_notification.new(123, "Hello World")
    result = await process_job(job)

    assert result["sent"] is True
```

It looks like async functions, decorated by the `@job` decorator, should return the result itself, not a coroutine. Thus, I expect the implementation to actually await the function result if needed.
If that's not intended, we should probably expand our docs to explain the result contracts better.

The current PR awaits for the result if it needs awaiting, before returning to the caller. Let me know if this makes sense