### PR TITLE
Await get_raw_connection in unwrap_connection

### DIFF
--- a/oban/_query.py
+++ b/oban/_query.py
@@ -58,7 +58,7 @@ async def unwrap_connection(conn: ConnectionLike) -> AsyncConnection | AsyncCurs
 
     # SQLAlchemy AsyncConnection
     if hasattr(conn, "get_raw_connection"):
-        raw = conn.get_raw_connection()
+        raw = await conn.get_raw_connection()
 
         if driver := getattr(raw, "dbapi_connection", None):
             return driver


### PR DESCRIPTION
`unwrap_connection()` calls `conn.get_raw_connection()` without `await` when handling a SQLAlchemy `AsyncConnection`. Since `AsyncConnection.get_raw_connection()` is an async method, the result is a coroutine object rather than the actual DBAPI connection, which causes `AttributeError: 'coroutine' object has no attribute 'execute'` downstream.

EDIT: Actually I think the issue might be different, im using `asyncpg` but it seems like Oban is built around `psycopg`, so the sessions aren't compatible?

## Environment

- oban-py: 0.5.2
- SQLAlchemy: 2.0.46
- psycopg: 3.3.2
- Python: 3.13

## Steps to reproduce

```python
from oban import Oban, worker, Job
from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker

engine = create_async_engine("postgresql+psycopg://...")
SessionLocal = async_sessionmaker(engine)

@worker(queue="default")
class MyWorker:
    async def process(self, job: Job) -> None:
        pass

async def main():
    oban = Oban(name="oban", pool=..., queues={"default": 10})

    async with oban:
        async with SessionLocal() as session:
            async with session.begin():
                # This fails — passing AsyncSession as conn
                await oban.enqueue_many(
                    [MyWorker.new({"key": "value"})],
                    conn=session,
                )
```

## Error

```
ubbe/billing/processor.py:65: in process_batch
    await self.oban.enqueue_many(
.venv/.../oban/oban.py:442: in enqueue_many
    return await self._query.insert_jobs(jobs, conn=conn)
.venv/.../oban/_query.py:254: in insert_jobs
    return await use_ext("query.insert_jobs", _insert_jobs, self, jobs, conn)
.venv/.../oban/_query.py:138: in _insert_jobs
    return await inner_insert(await unwrap_connection(conn))
.venv/.../oban/_query.py:124: in inner_insert
    result = await conn.execute(stmt, args)
                   ^^^^^^^^^^^^
AttributeError: 'coroutine' object has no attribute 'execute'
```