### PR TITLE
Use `Mapping` instead of `dict` for job args type

### DIFF
--- a/oban/worker.py
+++ b/oban/worker.py
@@ -5,6 +5,7 @@ implement, providing type hints for static analysis tools.
 """
 
 import importlib
+from collections.abc import Mapping
 from typing import Any, Protocol
 
 from .job import Job, Result
@@ -34,7 +35,7 @@ class Worker(Protocol):
     _oban_name: str
 
     @classmethod
-    def new(cls, args: dict[str, Any] | None = None, /, **params) -> Job:
+    def new(cls, args: Mapping[str, Any] | None = None, /, **params) -> Job:
         """Create a Job instance without enqueueing it.
 
         Args:
@@ -48,7 +49,7 @@ class Worker(Protocol):
 
     @classmethod
     async def enqueue(
-        cls, args: dict[str, Any] | None = None, /, conn=None, **overrides
+        cls, args: Mapping[str, Any] | None = None, /, conn=None, **overrides
     ) -> Job:
         """Create and enqueue a Job.
 


### PR DESCRIPTION
This will allow users to pass a TypedDict as the job args parameter, as well as a normal dictionary. This isn't a breaking change since `dict[str, Any]` satisfies `Mapping[str, Any]`

The pattern I've found myself using is:

```py
# In your worker

from typing import TypedDict
from pydantic import TypeAdapter

class FooWorkerArgs(TypedDict):
    bar: int


_args_adapter = TypeAdapter(FooWorkerArgs)


@worker()
class FooWorker:
    async def process(self, job: Job):
        args = _args_adapter.validate_python(job.args)
        ...


# Where your worker is created
from .foo_worker import FooWorker, FooWorkerArgs

FooWorker.new(FooWorkerArgs(bar=1))
```

The advantage here is that, as args signature changes, you can get type errors if you do not update your call sites. It also means that you can get type hints for `args` inside the process() method since it's been validated.

Currently I just add `  # pyright: ignore[reportArgumentType]` to the line where you call `.new()`, but that doesn't spark joy.